### PR TITLE
refactor: create the `Dungeon.Types` module

### DIFF
--- a/app/Dungeon.hs
+++ b/app/Dungeon.hs
@@ -4,10 +4,6 @@ module Dungeon
     ( initDungeon
     , Dungeon
     , completeThisTurn
-    , entities
-    , visible
-    , explored
-    , tileMap
     , popPlayer
     , popActorAt
     , enemies
@@ -39,6 +35,8 @@ import           Dungeon.Room                   (Room (..), x1, x2, y1, y2)
 import           Dungeon.Size                   (height, maxRooms, roomMaxSize,
                                                  roomMinSize, width)
 import qualified Dungeon.Turn                   as DT
+import           Dungeon.Types                  (Dungeon, dungeon, entities,
+                                                 explored, tileMap, visible)
 import           Entity                         (Entity (..), isAlive, name,
                                                  position)
 import qualified Entity                         as E
@@ -54,15 +52,6 @@ import           Map.Tile                       (Tile, TileMap, darkAttr,
                                                  walkable)
 import           System.Random.Stateful         (StdGen, newStdGen, random,
                                                  randomR)
-
-data Dungeon = Dungeon
-          { _tileMap  :: TileMap
-          , _visible  :: Fov
-          , _explored :: ExploredMap
-          , _entities :: [Entity]
-          } deriving (Show)
-makeLenses ''Dungeon
-
 completeThisTurn :: State Dungeon DT.Status
 completeThisTurn = do
         updateMap
@@ -97,7 +86,7 @@ getPlayerEntity d =
             Nothing -> error "No player entity."
 
 pushEntity :: Entity -> State Dungeon ()
-pushEntity e = state $ \d@Dungeon{ _entities = entities } -> ((), d { _entities = e:entities })
+pushEntity e = state $ \d -> ((), d & entities %~ (e :))
 
 popPlayer :: State Dungeon Entity
 popPlayer = state $ \d -> case runState (popActorIf (^. E.isPlayer)) d of
@@ -108,11 +97,12 @@ popActorAt :: Coord -> State Dungeon (Maybe Entity)
 popActorAt c = popActorIf (\x -> x ^. position == c)
 
 popActorIf :: (Entity -> Bool) -> State Dungeon (Maybe Entity)
-popActorIf f = state $ \d@Dungeon{ _entities = entities } ->
-    case findIndex f entities of
-        Just x -> let entity = entities !! x
-                      newEntities = take x entities ++ drop (x + 1) entities
-                  in (Just entity, d{ _entities = newEntities})
+popActorIf f = state $ \d ->
+    let xs = d ^. entities
+    in case findIndex f xs of
+        Just x -> let entity = xs !! x
+                      newEntities = take x xs ++ drop (x + 1) xs
+                  in (Just entity, d & entities .~ newEntities)
         Nothing -> (Nothing, d)
 
 walkableFloor :: Dungeon -> BoolMap
@@ -136,11 +126,8 @@ enemies d = filter (not . (^. E.isPlayer)) $ d ^. entities
 initDungeon :: IO Dungeon
 initDungeon = do
         gen <- newStdGen
-        let (dungeon, enemies, playerPos, _) = generateDungeon gen maxRooms roomMinSize roomMaxSize (V2 width height)
+        let (tileMap, enemies, playerPos, _) = generateDungeon gen maxRooms roomMinSize roomMaxSize (V2 width height)
         let player = E.player playerPos
-        let g = Dungeon { _tileMap = dungeon
-                        , _visible = emptyBoolMap
-                        , _explored = emptyBoolMap
-                        , _entities = player:enemies
-                        }
-        return $ execState updateMap g
+        let d = dungeon tileMap $ player:enemies
+
+        return $ execState updateMap d

--- a/app/Dungeon.hs
+++ b/app/Dungeon.hs
@@ -36,9 +36,9 @@ import           Dungeon.Size                   (height, maxRooms, roomMaxSize,
                                                  roomMinSize, width)
 import qualified Dungeon.Turn                   as DT
 import           Dungeon.Types                  (Dungeon, dungeon, entities,
-                                                 explored, tileMap, visible)
-import           Entity                         (Entity (..), isAlive, name,
-                                                 position)
+                                                 explored, isAlive, isPlayer,
+                                                 position, tileMap, visible)
+import           Entity                         (Entity (..))
 import qualified Entity                         as E
 import           Graphics.Vty.Attributes.Color  (Color, white, yellow)
 import           Linear.V2                      (V2 (..), _x, _y)
@@ -81,7 +81,7 @@ updateFov = do
 
 getPlayerEntity :: Dungeon -> Entity
 getPlayerEntity d =
-        case find (^. E.isPlayer) $ d ^. entities of
+        case find (^. isPlayer) $ d ^. entities of
             Just p  -> p
             Nothing -> error "No player entity."
 
@@ -89,7 +89,7 @@ pushEntity :: Entity -> State Dungeon ()
 pushEntity e = state $ \d -> ((), d & entities %~ (e :))
 
 popPlayer :: State Dungeon Entity
-popPlayer = state $ \d -> case runState (popActorIf (^. E.isPlayer)) d of
+popPlayer = state $ \d -> case runState (popActorIf (^. isPlayer)) d of
                   (Just x, d') -> (x, d')
                   (Nothing, _) -> error "No player entity."
 
@@ -112,7 +112,7 @@ transparentMap :: Dungeon -> BoolMap
 transparentMap d = fmap (^. transparent) (d ^. tileMap)
 
 enemyCoords :: Dungeon -> [Coord]
-enemyCoords d = map (^. position) $ filter (not . (^. E.isPlayer)) $ d ^. entities
+enemyCoords d = map (^. position) $ filter (not . (^. isPlayer)) $ d ^. entities
 
 isPlayerAlive :: Dungeon -> Bool
 isPlayerAlive d = getPlayerEntity d ^. isAlive
@@ -121,7 +121,7 @@ aliveEnemies :: Dungeon -> [Entity]
 aliveEnemies d = filter (^. isAlive) $ enemies d
 
 enemies :: Dungeon -> [Entity]
-enemies d = filter (not . (^. E.isPlayer)) $ d ^. entities
+enemies d = filter (not . (^. isPlayer)) $ d ^. entities
 
 initDungeon :: IO Dungeon
 initDungeon = do

--- a/app/Dungeon/Generate.hs
+++ b/app/Dungeon/Generate.hs
@@ -10,7 +10,8 @@ import           Dungeon.Room    (Room (..), center,
                                   roomFromTwoPositionInclusive,
                                   roomFromWidthHeight, roomOverlaps)
 import           Dungeon.Size    (height, width)
-import           Entity          (Entity, position)
+import           Dungeon.Types   (position)
+import           Entity          (Entity)
 import qualified Entity          as E
 import           Entity.Monsters (orc, troll)
 import           Linear.V2       (V2 (..), _x, _y)

--- a/app/Dungeon/Types.hs
+++ b/app/Dungeon/Types.hs
@@ -1,0 +1,37 @@
+-- This module is a workaround to avoid circular dependencies between
+-- `Dungeon` and `Entity`. The actual logics are defined in the `Dungeon`
+-- and `Entity` modules.
+--
+-- TODO: Define these types in each module if possible.
+
+{-# LANGUAGE TemplateHaskell #-}
+
+module Dungeon.Types
+    ( Dungeon
+    , dungeon
+    , tileMap
+    , visible
+    , explored
+    , entities
+    ) where
+
+import           Control.Lens (makeLenses)
+import           Entity       (Entity)
+import           Map.Explored (ExploredMap, initExploredMap)
+import           Map.Fov      (Fov, initFov)
+import           Map.Tile     (TileMap)
+
+data Dungeon = Dungeon
+          { _tileMap  :: TileMap
+          , _visible  :: Fov
+          , _explored :: ExploredMap
+          , _entities :: [Entity]
+          } deriving (Show)
+makeLenses ''Dungeon
+
+dungeon :: TileMap -> [Entity] -> Dungeon
+dungeon t e = Dungeon { _tileMap = t
+                      , _visible = initFov
+                      , _explored = initExploredMap
+                      , _entities = e
+                      }

--- a/app/Dungeon/Types.hs
+++ b/app/Dungeon/Types.hs
@@ -2,25 +2,70 @@
 -- `Dungeon` and `Entity`. The actual logics are defined in the `Dungeon`
 -- and `Entity` modules.
 --
+-- This module should define only the types and constructors.
+--
 -- TODO: Define these types in each module if possible.
 
 {-# LANGUAGE TemplateHaskell #-}
 
 module Dungeon.Types
     ( Dungeon
+    , Entity
+    , RenderOrder(..)
+    , Ai(..)
+    , path
     , dungeon
+    , actor
     , tileMap
     , visible
     , explored
     , entities
+    , position
+    , char
+    , entityAttr
+    , name
+    , hp
+    , maxHp
+    , defence
+    , power
+    , ai
+    , isAlive
+    , blocksMovement
+    , isPlayer
+    , renderOrder
     ) where
 
-import           Control.Lens (makeLenses)
-import           Entity       (Entity)
-import           Map.Explored (ExploredMap, initExploredMap)
-import           Map.Fov      (Fov, initFov)
-import           Map.Tile     (TileMap)
+import           Brick.AttrMap (AttrName)
+import           Control.Lens  (makeLenses)
+import           Coord         (Coord)
+import           Map.Explored  (ExploredMap, initExploredMap)
+import           Map.Fov       (Fov, initFov)
+import           Map.Tile      (TileMap)
 
+
+newtype Ai = HostileEnemy
+             { _path :: [Coord]
+             } deriving (Show)
+makeLenses ''Ai
+
+data RenderOrder =  ActorEntity| Iten | Corpse deriving (Show, Ord, Eq)
+
+data Entity = Actor
+            { _position       :: Coord
+            , _char           :: String
+            , _entityAttr     :: AttrName
+            , _name           :: String
+            , _hp             :: Int
+            , _maxHp          :: Int
+            , _defence        :: Int
+            , _power          :: Int
+            , _ai             :: Ai
+            , _isAlive        :: Bool
+            , _blocksMovement :: Bool
+            , _isPlayer       :: Bool
+            , _renderOrder    :: RenderOrder
+            } deriving (Show)
+makeLenses ''Entity
 data Dungeon = Dungeon
           { _tileMap  :: TileMap
           , _visible  :: Fov
@@ -35,3 +80,23 @@ dungeon t e = Dungeon { _tileMap = t
                       , _explored = initExploredMap
                       , _entities = e
                       }
+
+actor :: Coord -> String -> AttrName -> String -> Int -> Int -> Int -> Bool -> Bool -> Bool -> RenderOrder -> Entity
+actor position char entityAttr name hp defence power isAlive blocksMovement isPlayer renderOrder =
+        Actor { _position = position
+              , _char = char
+              , _entityAttr = entityAttr
+              , _name = name
+              , _hp = hp
+              , _maxHp = hp
+              , _defence = defence
+              , _power = power
+              , _ai = hostileEnemy
+              , _isAlive = isAlive
+              , _blocksMovement = blocksMovement
+              , _isPlayer = isPlayer
+              , _renderOrder = renderOrder
+              }
+
+hostileEnemy :: Ai
+hostileEnemy = HostileEnemy { _path = [] }

--- a/app/Engine.hs
+++ b/app/Engine.hs
@@ -23,7 +23,8 @@ import           Dungeon.Generate               (generateDungeon)
 import           Dungeon.Size                   (height, maxRooms, roomMaxSize,
                                                  roomMinSize, width)
 import qualified Dungeon.Turn                   as DT
-import           Entity                         (Entity (..), position)
+import           Dungeon.Types                  (maxHp, position)
+import           Entity                         (Entity (..))
 import qualified Entity                         as E
 import           Entity.Behavior                (bumpAction, enemyAction)
 import           Event                          (Event, gameStartEvent)
@@ -100,7 +101,7 @@ playerCurrentHp :: Engine -> Int
 playerCurrentHp e = E.getHp $ getPlayerEntity (e ^?! dungeon)
 
 playerMaxHp :: Engine -> Int
-playerMaxHp e = getPlayerEntity (e ^?! dungeon) ^. E.maxHp
+playerMaxHp e = getPlayerEntity (e ^?! dungeon) ^. maxHp
 
 initEngine :: IO Engine
 initEngine = do

--- a/app/Entity/Behavior.hs
+++ b/app/Entity/Behavior.hs
@@ -16,11 +16,12 @@ import           Dungeon                   (Dungeon, enemies, getPlayerEntity,
                                             popActorAt, pushEntity)
 import           Dungeon.PathFinder        (getPathTo)
 import qualified Dungeon.Size              as DS
-import           Dungeon.Types             (entities, tileMap, visible)
-import           Entity                    (Ai (..), Entity, ai, blocksMovement,
-                                            defence, getHp, isAlive, isPlayer,
-                                            name, path, position, power,
-                                            updateHp)
+import           Dungeon.Types             (Ai (HostileEnemy, _path), Entity,
+                                            ai, blocksMovement, defence,
+                                            entities, isAlive, isPlayer, name,
+                                            path, position, power, tileMap,
+                                            visible)
+import           Entity                    (getHp, updateHp)
 import           Linear.V2                 (V2 (..), _x, _y)
 import           Log                       (Message, message)
 import           Map.Tile                  (walkable)

--- a/app/Entity/Behavior.hs
+++ b/app/Entity/Behavior.hs
@@ -12,11 +12,11 @@ import           Coord                     (Coord)
 import           Data.Array                ((!))
 import           Data.List                 (find)
 import           Data.Maybe                (fromMaybe, isJust, isNothing)
-import           Dungeon                   (Dungeon, enemies, entities,
-                                            getPlayerEntity, popActorAt,
-                                            pushEntity, tileMap, visible)
+import           Dungeon                   (Dungeon, enemies, getPlayerEntity,
+                                            popActorAt, pushEntity)
 import           Dungeon.PathFinder        (getPathTo)
 import qualified Dungeon.Size              as DS
+import           Dungeon.Types             (entities, tileMap, visible)
 import           Entity                    (Ai (..), Entity, ai, blocksMovement,
                                             defence, getHp, isAlive, isPlayer,
                                             name, path, position, power,

--- a/app/Map/Fov.hs
+++ b/app/Map/Fov.hs
@@ -1,5 +1,6 @@
 module Map.Fov
     ( Fov
+    , initFov
     , calculateFov
     ) where
 
@@ -13,6 +14,9 @@ type Fov = BoolMap
 
 fovRadius :: Int
 fovRadius = 8
+
+initFov :: Fov
+initFov = emptyBoolMap
 
 calculateFov :: Coord -> BoolMap -> Fov
 calculateFov (V2 x0 y0) transparentMap =

--- a/app/UI.hs
+++ b/app/UI.hs
@@ -21,9 +21,9 @@ import           Control.Monad.Trans.State  (execState, get)
 import           Data.Array.Base            ((!))
 import           Data.List                  (sortOn)
 import           Data.Maybe                 (fromMaybe)
-import           Dungeon                    (entities, explored, tileMap,
-                                             visible)
 import           Dungeon.Size               (height, width)
+import           Dungeon.Types              (entities, explored, tileMap,
+                                             visible)
 import           Engine                     (Engine (Engine, HandlingEvent, _event),
                                              afterFinish, completeThisTurn,
                                              dungeon, event, initEngine,

--- a/app/UI.hs
+++ b/app/UI.hs
@@ -22,16 +22,15 @@ import           Data.Array.Base            ((!))
 import           Data.List                  (sortOn)
 import           Data.Maybe                 (fromMaybe)
 import           Dungeon.Size               (height, width)
-import           Dungeon.Types              (entities, explored, tileMap,
-                                             visible)
+import           Dungeon.Types              (char, entities, entityAttr,
+                                             explored, position, renderOrder,
+                                             tileMap, visible)
 import           Engine                     (Engine (Engine, HandlingEvent, _event),
                                              afterFinish, completeThisTurn,
                                              dungeon, event, initEngine,
                                              isGameOver, messageLog,
                                              playerBumpAction, playerCurrentHp,
                                              playerMaxHp)
-import           Entity                     (char, entityAttr, position,
-                                             renderOrder)
 import           Event                      (numMessages, popMessage)
 import qualified Graphics.Vty               as V
 import           Linear.V2                  (V2 (..), _x, _y)

--- a/roguelike.cabal
+++ b/roguelike.cabal
@@ -34,6 +34,7 @@ executable roguelike
                       , Map.Explored
                       , Map.Fov
                       , Dungeon
+                      , Dungeon.Types
                       , Dungeon.Room
                       , Dungeon.Size
                       , Dungeon.Generate


### PR DESCRIPTION
This is a workaround to avoid circular dependencies between `Dungeon` and `Entity`.
