### PR TITLE
refactor: move the position of the `Player` module

### DIFF
--- a/roguelike.cabal
+++ b/roguelike.cabal
@@ -23,6 +23,7 @@ executable roguelike
                       , Dungeon.Actor.Behavior
                       , Dungeon.Actor.Friendly
                       , Dungeon.Actor.Inventory
+                      , Dungeon.Actor.Player
                       , Dungeon.Actor.Monsters
                       , Dungeon.Actor.Status
                       , Dungeon.Actor.Status.Hp
@@ -46,7 +47,6 @@ executable roguelike
                       , Game.Config
                       , Game.Status
                       , Game.Status.Exploring
-                      , Game.Status.Player
                       , Game.Status.Scene
                       , Game.Status.SelectingItemToUse
                       , Game.Status.Talking

--- a/src/Dungeon/Actor/Player.hs
+++ b/src/Dungeon/Actor/Player.hs
@@ -1,4 +1,4 @@
-module Game.Status.Player
+module Dungeon.Actor.Player
     ( playerBumpAction
     , handlePlayerMoving
     , handlePlayerPickingUp

--- a/src/UI/Event.hs
+++ b/src/UI/Event.hs
@@ -6,6 +6,10 @@ module UI.Event
 
 import           Data.Maybe                     (fromMaybe)
 import           Data.Text                      (Text)
+import           Dungeon.Actor.Player           (handlePlayerConsumeItem,
+                                                 handlePlayerMoving,
+                                                 handlePlayerPickingUp,
+                                                 handlePlayerSelectingItemToUse)
 import           Game                           (Game (Game, config, status))
 import           Game.Config                    (Language (English, Japanese),
                                                  setLocale, writeConfig)
@@ -13,10 +17,6 @@ import           Game.Status                    (GameStatus (Exploring, GameOver
                                                  newGameStatus)
 import           Game.Status.Exploring          (ascendStairsAtPlayerPosition,
                                                  descendStairsAtPlayerPosition)
-import           Game.Status.Player             (handlePlayerConsumeItem,
-                                                 handlePlayerMoving,
-                                                 handlePlayerPickingUp,
-                                                 handlePlayerSelectingItemToUse)
 import           Game.Status.Scene              (nextSceneOrFinish)
 import           Game.Status.SelectingItemToUse (finishSelecting,
                                                  selectNextItem, selectPrevItem)


### PR DESCRIPTION
I do not know where is the best position, but at least a player is an
actor, so I moved the module under `Dungeon.Actor`.
