### PR TITLE
refactor: move some parts of `Exploring` to `Dungeons`

### DIFF
--- a/roguelike.cabal
+++ b/roguelike.cabal
@@ -47,6 +47,7 @@ executable roguelike
                       , Game.Config
                       , Game.Status
                       , Game.Status.Exploring
+                      , Game.Status.Exploring.Dungeons
                       , Game.Status.Scene
                       , Game.Status.SelectingItemToUse
                       , Game.Status.Talking

--- a/src/Dungeon.hs
+++ b/src/Dungeon.hs
@@ -14,6 +14,7 @@ module Dungeon
     , completeThisTurn
     , popPlayer
     , popActorAt
+    , popActorIf
     , monsters
     , pushActor
     , walkableFloor

--- a/src/Game/Status/Exploring.hs
+++ b/src/Game/Status/Exploring.hs
@@ -17,29 +17,32 @@ module Game.Status.Exploring
     , getMessageLog
     ) where
 
-import           Control.Lens               ((%~), (&), (.~), (^.))
-import           Control.Monad.Trans.Maybe  (MaybeT (runMaybeT))
-import           Control.Monad.Trans.Writer (runWriter)
-import           Coord                      (Coord)
-import           Data.Binary                (Binary)
-import           Data.Foldable              (find)
-import           Dungeon                    (Dungeon, actors, ascendingStairs,
-                                             descendingStairs, npcs, popPlayer,
-                                             positionOnParentMap, updateMap)
-import qualified Dungeon                    as D
-import           Dungeon.Actor              (Actor, position)
-import           Dungeon.Actor.Actions      (Action)
-import           Dungeon.Actor.Behavior     (npcAction)
-import           Dungeon.Stairs             (StairsPair (StairsPair, downStairs, upStairs))
-import           Dungeon.Turn               (Status (PlayerKilled))
-import           GHC.Generics               (Generic)
-import           Log                        (Message, MessageLog)
-import qualified Log                        as L
-import           TreeZipper                 (TreeZipper, getFocused, goDownBy,
-                                             goUp, modify)
+import           Control.Lens                   ((%~), (&), (.~), (^.))
+import           Control.Monad.Trans.Maybe      (MaybeT (runMaybeT))
+import           Control.Monad.Trans.Writer     (runWriter)
+import           Coord                          (Coord)
+import           Data.Binary                    (Binary)
+import           Data.Foldable                  (find)
+import           Dungeon                        (Dungeon, actors,
+                                                 descendingStairs, npcs,
+                                                 popPlayer, positionOnParentMap,
+                                                 updateMap)
+import qualified Dungeon                        as D
+import           Dungeon.Actor                  (Actor, position)
+import           Dungeon.Actor.Actions          (Action)
+import           Dungeon.Actor.Behavior         (npcAction)
+import           Dungeon.Stairs                 (StairsPair (StairsPair, downStairs))
+import           Dungeon.Turn                   (Status (PlayerKilled))
+import           GHC.Generics                   (Generic)
+import           Game.Status.Exploring.Dungeons (Dungeons)
+import qualified Game.Status.Exploring.Dungeons as DS
+import           Log                            (Message, MessageLog)
+import qualified Log                            as L
+import           TreeZipper                     (TreeZipper, getFocused,
+                                                 goDownBy, goUp, modify)
 
 data ExploringHandler = ExploringHandler
-                      { dungeons   :: TreeZipper Dungeon
+                      { dungeons   :: Dungeons
                       , messageLog :: MessageLog
                       } deriving (Show, Ord, Eq, Generic)
 
@@ -50,18 +53,7 @@ exploringHandler = ExploringHandler
 
 ascendStairsAtPlayerPosition :: ExploringHandler -> Maybe ExploringHandler
 ascendStairsAtPlayerPosition eh@ExploringHandler { dungeons = ds } =
-        fmap (\x -> eh { dungeons = x }) newZipper
-    where (player, zipperWithoutPlayer) = popPlayerFromZipper ds
-          newPlayer = case (player, newPosition) of
-                          (Just p, Just pos) -> Just $ p & position .~ pos
-                          _                  -> Nothing
-          ascendable = (downStairs <$> getFocused ds ^. ascendingStairs) == fmap (^. position) player
-          zipperFocusingNextDungeon = goUp zipperWithoutPlayer
-          newPosition = upStairs <$> getFocused ds ^. ascendingStairs
-          newZipper = case (zipperFocusingNextDungeon, newPlayer, ascendable) of
-                          (Just g, Just p, True) ->
-                                Just $ modify (\d -> updateMap $ d & actors %~ (:) p) g
-                          _ -> Nothing
+    (\x -> eh { dungeons = x }) <$> DS.ascendStairsAtPlayerPosition ds
 
 descendStairsAtPlayerPosition :: ExploringHandler -> Maybe ExploringHandler
 descendStairsAtPlayerPosition eh@ExploringHandler{ dungeons = ds } =

--- a/src/Game/Status/Exploring.hs
+++ b/src/Game/Status/Exploring.hs
@@ -17,13 +17,12 @@ module Game.Status.Exploring
     , getMessageLog
     ) where
 
-import           Control.Lens                   ((%~), (&), (.~), (^.))
+import           Control.Lens                   ((^.))
 import           Control.Monad.Trans.Maybe      (MaybeT (runMaybeT))
 import           Control.Monad.Trans.Writer     (runWriter)
 import           Coord                          (Coord)
 import           Data.Binary                    (Binary)
-import           Dungeon                        (Dungeon, actors, npcs,
-                                                 popPlayer, positionOnParentMap)
+import           Dungeon                        (Dungeon, npcs, popPlayer)
 import qualified Dungeon                        as D
 import           Dungeon.Actor                  (Actor, position)
 import           Dungeon.Actor.Actions          (Action)
@@ -34,8 +33,7 @@ import           Game.Status.Exploring.Dungeons (Dungeons)
 import qualified Game.Status.Exploring.Dungeons as DS
 import           Log                            (Message, MessageLog)
 import qualified Log                            as L
-import           TreeZipper                     (TreeZipper, getFocused, goUp,
-                                                 modify)
+import           TreeZipper                     (TreeZipper, getFocused, modify)
 
 data ExploringHandler = ExploringHandler
                       { dungeons   :: Dungeons
@@ -57,18 +55,7 @@ descendStairsAtPlayerPosition eh@ExploringHandler { dungeons = ds } =
 
 exitDungeon :: ExploringHandler -> Maybe ExploringHandler
 exitDungeon eh@ExploringHandler { dungeons = ds } =
-    fmap (\ds' -> eh { dungeons = ds' }) newZipper
-    where zipperWithoutPlayer = modify (snd . popPlayer) ds
-          currentDungeon = getFocused ds
-          player = fst $ popPlayer currentDungeon
-          newPosition = currentDungeon ^. positionOnParentMap
-          newPlayer = case (player, newPosition) of
-                          (Just p, Just pos) -> Just $ p & position .~ pos
-                          _                  -> Nothing
-          zipperFocusingGlobalMap = goUp zipperWithoutPlayer
-          newZipper = case (zipperFocusingGlobalMap, newPlayer) of
-                          (Just g, Just p) -> Just $ modify (\d -> d & actors %~ (:) p) g
-                          _                -> Nothing
+    (\x -> eh { dungeons = x }) <$> DS.exitDungeon ds
 
 doPlayerAction :: Action -> ExploringHandler -> (Bool, ExploringHandler)
 doPlayerAction action eh@ExploringHandler { dungeons = ds } = result

--- a/src/Game/Status/Exploring.hs
+++ b/src/Game/Status/Exploring.hs
@@ -26,7 +26,6 @@ import           Dungeon                        (Dungeon, npcs)
 import qualified Dungeon                        as D
 import           Dungeon.Actor                  (Actor, position)
 import           Dungeon.Actor.Actions          (Action)
-import           Dungeon.Actor.Behavior         (npcAction)
 import           Dungeon.Turn                   (Status (PlayerKilled))
 import           GHC.Generics                   (Generic)
 import           Game.Status.Exploring.Dungeons (Dungeons)
@@ -79,24 +78,11 @@ handleNpcTurns :: ExploringHandler -> ExploringHandler
 handleNpcTurns eh = foldl (\acc x -> handleNpcTurn (x ^. position) acc) eh $ npcs $ getCurrentDungeon eh
 
 handleNpcTurn :: Coord -> ExploringHandler -> ExploringHandler
-handleNpcTurn c eh@ExploringHandler { dungeons = ds } = newHandler
-    where newHandler = case theActor of
-                           Just x  -> doAction x
-                           Nothing -> error "No such npc."
-
-          theActor = fst . D.popActorAt c $ getFocused ds
-
-          doAction actor = let (newCurrentDungeon, generatedLog) =
-                                    runWriter $ runMaybeT $ npcAction actor $ getFocused dungeonsWithoutTheActor
-                           in case newCurrentDungeon of
-                                   Just d  -> updateDungeonAndLog d generatedLog
-                                   Nothing -> eh
-
-          dungeonsWithoutTheActor = modify (snd . D.popActorAt c) ds
-
-          updateDungeonAndLog d l = eh { dungeons = modify (const d) dungeonsWithoutTheActor
-                                       , messageLog = L.addMessages l $ getMessageLog eh
-                                       }
+handleNpcTurn c ExploringHandler { dungeons = ds, messageLog = l } = result
+    where (dungeonsAfterTurn, newLog) = runWriter $ runMaybeT $ DS.handleNpcTurn c ds
+          result = case dungeonsAfterTurn of
+                    Just x -> ExploringHandler { dungeons = x, messageLog = L.addMessages newLog l }
+                    Nothing -> ExploringHandler { dungeons = ds, messageLog = l }
 
 getPlayerActor :: ExploringHandler -> Maybe Actor
 getPlayerActor = D.getPlayerActor . getCurrentDungeon

--- a/src/Game/Status/Exploring.hs
+++ b/src/Game/Status/Exploring.hs
@@ -22,7 +22,7 @@ import           Control.Monad.Trans.Maybe      (MaybeT (runMaybeT))
 import           Control.Monad.Trans.Writer     (runWriter)
 import           Coord                          (Coord)
 import           Data.Binary                    (Binary)
-import           Dungeon                        (Dungeon, npcs, popPlayer)
+import           Dungeon                        (Dungeon, npcs)
 import qualified Dungeon                        as D
 import           Dungeon.Actor                  (Actor, position)
 import           Dungeon.Actor.Actions          (Action)
@@ -58,18 +58,14 @@ exitDungeon eh@ExploringHandler { dungeons = ds } =
     (\x -> eh { dungeons = x }) <$> DS.exitDungeon ds
 
 doPlayerAction :: Action -> ExploringHandler -> (Bool, ExploringHandler)
-doPlayerAction action eh@ExploringHandler { dungeons = ds } = result
-    where currentDungeon = getFocused ds
-          (player, dungeonWithoutPlayer) = popPlayer currentDungeon
-          result = case player of
-                    Just p -> let (newCurrentDungeon, newLogs) =
-                                    runWriter $ runMaybeT $ action p dungeonWithoutPlayer
-                                  handlerWithNewLog =
-                                    addMessages newLogs eh
-                              in case newCurrentDungeon of
-                                     Just x -> (True, handlerWithNewLog { dungeons = modify (const x) ds })
-                                     Nothing -> (False, handlerWithNewLog)
-                    Nothing -> (False, eh)
+doPlayerAction action ExploringHandler { dungeons = ds, messageLog = l } =
+    result
+    where (dungeonsAfterAction, newLog) = runWriter $ runMaybeT $ DS.doPlayerAction action ds
+          handlerWithNewLog = ExploringHandler { dungeons = ds, messageLog = L.addMessages newLog l }
+
+          result = case dungeonsAfterAction of
+                       Just x  -> (True, handlerWithNewLog { dungeons = x })
+                       Nothing -> (False, handlerWithNewLog)
 
 completeThisTurn :: ExploringHandler -> Maybe ExploringHandler
 completeThisTurn eh =

--- a/src/Game/Status/Exploring.hs
+++ b/src/Game/Status/Exploring.hs
@@ -22,24 +22,20 @@ import           Control.Monad.Trans.Maybe      (MaybeT (runMaybeT))
 import           Control.Monad.Trans.Writer     (runWriter)
 import           Coord                          (Coord)
 import           Data.Binary                    (Binary)
-import           Data.Foldable                  (find)
-import           Dungeon                        (Dungeon, actors,
-                                                 descendingStairs, npcs,
-                                                 popPlayer, positionOnParentMap,
-                                                 updateMap)
+import           Dungeon                        (Dungeon, actors, npcs,
+                                                 popPlayer, positionOnParentMap)
 import qualified Dungeon                        as D
 import           Dungeon.Actor                  (Actor, position)
 import           Dungeon.Actor.Actions          (Action)
 import           Dungeon.Actor.Behavior         (npcAction)
-import           Dungeon.Stairs                 (StairsPair (StairsPair, downStairs))
 import           Dungeon.Turn                   (Status (PlayerKilled))
 import           GHC.Generics                   (Generic)
 import           Game.Status.Exploring.Dungeons (Dungeons)
 import qualified Game.Status.Exploring.Dungeons as DS
 import           Log                            (Message, MessageLog)
 import qualified Log                            as L
-import           TreeZipper                     (TreeZipper, getFocused,
-                                                 goDownBy, goUp, modify)
+import           TreeZipper                     (TreeZipper, getFocused, goUp,
+                                                 modify)
 
 data ExploringHandler = ExploringHandler
                       { dungeons   :: Dungeons
@@ -56,20 +52,8 @@ ascendStairsAtPlayerPosition eh@ExploringHandler { dungeons = ds } =
     (\x -> eh { dungeons = x }) <$> DS.ascendStairsAtPlayerPosition ds
 
 descendStairsAtPlayerPosition :: ExploringHandler -> Maybe ExploringHandler
-descendStairsAtPlayerPosition eh@ExploringHandler{ dungeons = ds } =
-    fmap (\x -> eh { dungeons = x }) newZipper
-    where (player, zipperWithoutPlayer) = popPlayerFromZipper ds
-          newPlayer = case (player, newPosition) of
-                          (Just p, Just pos) -> Just $ p & position .~ pos
-                          _                  -> Nothing
-          zipperFocusingNextDungeon = goDownBy (\x -> x ^. positionOnParentMap == fmap (^. position) player) zipperWithoutPlayer
-          newPosition = downStairs <$> find (\(StairsPair from _) -> Just from == fmap (^. position) player) (getFocused ds ^. descendingStairs)
-          newZipper = case (zipperFocusingNextDungeon, newPlayer) of
-                          (Just g, Just p) -> Just $ modify (\d -> updateMap $ d & actors %~ (:) p) g
-                          _ -> Nothing
-
-popPlayerFromZipper :: TreeZipper Dungeon -> (Maybe Actor, TreeZipper Dungeon)
-popPlayerFromZipper z = (fst $ popPlayer $ getFocused z, modify (snd . popPlayer) z)
+descendStairsAtPlayerPosition eh@ExploringHandler { dungeons = ds } =
+    (\x -> eh { dungeons = x }) <$> DS.descendStairsAtPlayerPosition ds
 
 exitDungeon :: ExploringHandler -> Maybe ExploringHandler
 exitDungeon eh@ExploringHandler { dungeons = ds } =

--- a/src/Game/Status/Exploring/Dungeons.hs
+++ b/src/Game/Status/Exploring/Dungeons.hs
@@ -15,7 +15,7 @@ import           Dungeon                    (Dungeon, actors, ascendingStairs,
                                              descendingStairs,
                                              positionOnParentMap, updateMap)
 import qualified Dungeon                    as D
-import           Dungeon.Actor              (Actor, position)
+import           Dungeon.Actor              (Actor, isPlayer, position)
 import           Dungeon.Actor.Actions      (Action)
 import           Dungeon.Stairs             (StairsPair (StairsPair, downStairs, upStairs))
 import           Log                        (MessageLog)
@@ -73,4 +73,7 @@ doPlayerAction action ds = result
                        Nothing -> mzero
 
 popPlayer :: Dungeons -> (Maybe Actor, Dungeons)
-popPlayer z = (fst $ D.popPlayer $ getFocused z, modify (snd . D.popPlayer) z)
+popPlayer = popActorIf isPlayer
+
+popActorIf :: (Actor -> Bool) -> Dungeons -> (Maybe Actor, Dungeons)
+popActorIf f z = (fst $ D.popActorIf f $ getFocused z, modify (snd . D.popActorIf f) z)

--- a/src/Game/Status/Exploring/Dungeons.hs
+++ b/src/Game/Status/Exploring/Dungeons.hs
@@ -1,0 +1,30 @@
+module Game.Status.Exploring.Dungeons
+    ( Dungeons
+    , ascendStairsAtPlayerPosition
+    ) where
+
+import           Control.Lens   ((%~), (&), (.~), (^.))
+import           Dungeon        (Dungeon, actors, ascendingStairs, updateMap)
+import qualified Dungeon        as D
+import           Dungeon.Actor  (Actor, position)
+import           Dungeon.Stairs (StairsPair (downStairs, upStairs))
+import           TreeZipper     (TreeZipper, getFocused, goUp, modify)
+
+type Dungeons = TreeZipper Dungeon
+
+ascendStairsAtPlayerPosition :: Dungeons -> Maybe Dungeons
+ascendStairsAtPlayerPosition ds = newZipper
+    where (player, zipperWithoutPlayer) = popPlayer ds
+          newPlayer = case (player, newPosition) of
+                          (Just p, Just pos) -> Just $ p & position .~ pos
+                          _                  -> Nothing
+          ascendable = (downStairs <$> getFocused ds ^. ascendingStairs) == fmap (^. position) player
+          zipperFocusingNextDungeon = goUp zipperWithoutPlayer
+          newPosition = upStairs <$> getFocused ds ^. ascendingStairs
+          newZipper = case (zipperFocusingNextDungeon, newPlayer, ascendable) of
+                          (Just g, Just p, True) ->
+                                Just $ modify (\d -> updateMap $ d & actors %~ (:) p) g
+                          _ -> Nothing
+
+popPlayer :: TreeZipper Dungeon -> (Maybe Actor, Dungeons)
+popPlayer z = (fst $ D.popPlayer $ getFocused z, modify (snd . D.popPlayer) z)

--- a/src/Game/Status/Exploring/Dungeons.hs
+++ b/src/Game/Status/Exploring/Dungeons.hs
@@ -2,6 +2,7 @@ module Game.Status.Exploring.Dungeons
     ( Dungeons
     , ascendStairsAtPlayerPosition
     , descendStairsAtPlayerPosition
+    , exitDungeon
     ) where
 
 import           Control.Lens   ((%~), (&), (.~), (^.))
@@ -42,6 +43,18 @@ descendStairsAtPlayerPosition ds = newZipper
                           (Just g, Just p) -> Just $ modify (\d -> updateMap $ d & actors %~ (:) p) g
                           _ -> Nothing
 
+exitDungeon :: Dungeons -> Maybe Dungeons
+exitDungeon ds = newZipper
+    where (player, zipperWithoutPlayer) = popPlayer ds
+          currentDungeon = getFocused ds
+          newPosition = currentDungeon ^. positionOnParentMap
+          newPlayer = case (player, newPosition) of
+                          (Just p, Just pos) -> Just $ p & position .~ pos
+                          _                  -> Nothing
+          zipperFocusingGlobalMap = goUp zipperWithoutPlayer
+          newZipper = case (zipperFocusingGlobalMap, newPlayer) of
+                          (Just g, Just p) -> Just $ modify (\d -> d & actors %~ (:) p) g
+                          _                -> Nothing
 
-popPlayer :: TreeZipper Dungeon -> (Maybe Actor, Dungeons)
+popPlayer :: Dungeons -> (Maybe Actor, Dungeons)
 popPlayer z = (fst $ D.popPlayer $ getFocused z, modify (snd . D.popPlayer) z)

--- a/src/Game/Status/Exploring/Dungeons.hs
+++ b/src/Game/Status/Exploring/Dungeons.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
 module Game.Status.Exploring.Dungeons
     ( Dungeons
     , ascendStairsAtPlayerPosition

--- a/src/Game/Status/Exploring/Dungeons.hs
+++ b/src/Game/Status/Exploring/Dungeons.hs
@@ -4,12 +4,14 @@ module Game.Status.Exploring.Dungeons
     , descendStairsAtPlayerPosition
     , exitDungeon
     , doPlayerAction
+    , handleNpcTurn
     ) where
 
 import           Control.Lens               ((%~), (&), (.~), (^.))
 import           Control.Monad              (MonadPlus (mzero))
 import           Control.Monad.Trans.Maybe  (MaybeT, mapMaybeT)
 import           Control.Monad.Trans.Writer (Writer)
+import           Coord                      (Coord)
 import           Data.Foldable              (find)
 import           Dungeon                    (Dungeon, actors, ascendingStairs,
                                              descendingStairs,
@@ -17,6 +19,7 @@ import           Dungeon                    (Dungeon, actors, ascendingStairs,
 import qualified Dungeon                    as D
 import           Dungeon.Actor              (Actor, isPlayer, position)
 import           Dungeon.Actor.Actions      (Action)
+import           Dungeon.Actor.Behavior     (npcAction)
 import           Dungeon.Stairs             (StairsPair (StairsPair, downStairs, upStairs))
 import           Log                        (MessageLog)
 import           TreeZipper                 (TreeZipper, getFocused, goDownBy,
@@ -72,8 +75,21 @@ doPlayerAction action ds = result
                                   in mapMaybeT (fmap (fmap (\d -> modify (const d) zipperWithoutPlayer))) dungeonAfterAction
                        Nothing -> mzero
 
+handleNpcTurn :: Coord -> Dungeons -> MaybeT (Writer MessageLog) Dungeons
+handleNpcTurn c ds = newDungeons
+    where (theActor, dungeonsWithoutTheActor) = popActorAt c ds
+
+          doAction actor = npcAction actor $ getFocused dungeonsWithoutTheActor
+
+          newDungeon = maybe mzero doAction theActor
+
+          newDungeons = mapMaybeT (fmap (fmap (\d -> modify (const d) dungeonsWithoutTheActor))) newDungeon
+
 popPlayer :: Dungeons -> (Maybe Actor, Dungeons)
 popPlayer = popActorIf isPlayer
+
+popActorAt :: Coord -> Dungeons -> (Maybe Actor, Dungeons)
+popActorAt c = popActorIf (\x -> x ^. position == c)
 
 popActorIf :: (Actor -> Bool) -> Dungeons -> (Maybe Actor, Dungeons)
 popActorIf f z = (fst $ D.popActorIf f $ getFocused z, modify (snd . D.popActorIf f) z)

--- a/src/Game/Status/Exploring/Dungeons.hs
+++ b/src/Game/Status/Exploring/Dungeons.hs
@@ -1,19 +1,27 @@
+{-# LANGUAGE LambdaCase #-}
 module Game.Status.Exploring.Dungeons
     ( Dungeons
     , ascendStairsAtPlayerPosition
     , descendStairsAtPlayerPosition
     , exitDungeon
+    , doPlayerAction
     ) where
 
-import           Control.Lens   ((%~), (&), (.~), (^.))
-import           Data.Foldable  (find)
-import           Dungeon        (Dungeon, actors, ascendingStairs,
-                                 descendingStairs, positionOnParentMap,
-                                 updateMap)
-import qualified Dungeon        as D
-import           Dungeon.Actor  (Actor, position)
-import           Dungeon.Stairs (StairsPair (StairsPair, downStairs, upStairs))
-import           TreeZipper     (TreeZipper, getFocused, goDownBy, goUp, modify)
+import           Control.Lens               ((%~), (&), (.~), (^.))
+import           Control.Monad              (MonadPlus (mzero))
+import           Control.Monad.Trans.Maybe  (MaybeT, mapMaybeT)
+import           Control.Monad.Trans.Writer (Writer)
+import           Data.Foldable              (find)
+import           Dungeon                    (Dungeon, actors, ascendingStairs,
+                                             descendingStairs,
+                                             positionOnParentMap, updateMap)
+import qualified Dungeon                    as D
+import           Dungeon.Actor              (Actor, position)
+import           Dungeon.Actor.Actions      (Action)
+import           Dungeon.Stairs             (StairsPair (StairsPair, downStairs, upStairs))
+import           Log                        (MessageLog)
+import           TreeZipper                 (TreeZipper, getFocused, goDownBy,
+                                             goUp, modify)
 
 type Dungeons = TreeZipper Dungeon
 
@@ -55,6 +63,15 @@ exitDungeon ds = newZipper
           newZipper = case (zipperFocusingGlobalMap, newPlayer) of
                           (Just g, Just p) -> Just $ modify (\d -> d & actors %~ (:) p) g
                           _                -> Nothing
+
+doPlayerAction :: Action -> Dungeons -> MaybeT (Writer MessageLog) Dungeons
+doPlayerAction action ds = result
+    where (player, zipperWithoutPlayer) = popPlayer ds
+          currentDungeonWithoutPlayer = getFocused zipperWithoutPlayer
+          result = case player of
+                       Just p  -> let dungeonAfterAction = action p currentDungeonWithoutPlayer
+                                  in mapMaybeT (fmap (fmap (\d -> modify (const d) zipperWithoutPlayer))) dungeonAfterAction
+                       Nothing -> mzero
 
 popPlayer :: Dungeons -> (Maybe Actor, Dungeons)
 popPlayer z = (fst $ D.popPlayer $ getFocused z, modify (snd . D.popPlayer) z)

--- a/src/Game/Status/Exploring/Dungeons.hs
+++ b/src/Game/Status/Exploring/Dungeons.hs
@@ -1,14 +1,18 @@
 module Game.Status.Exploring.Dungeons
     ( Dungeons
     , ascendStairsAtPlayerPosition
+    , descendStairsAtPlayerPosition
     ) where
 
 import           Control.Lens   ((%~), (&), (.~), (^.))
-import           Dungeon        (Dungeon, actors, ascendingStairs, updateMap)
+import           Data.Foldable  (find)
+import           Dungeon        (Dungeon, actors, ascendingStairs,
+                                 descendingStairs, positionOnParentMap,
+                                 updateMap)
 import qualified Dungeon        as D
 import           Dungeon.Actor  (Actor, position)
-import           Dungeon.Stairs (StairsPair (downStairs, upStairs))
-import           TreeZipper     (TreeZipper, getFocused, goUp, modify)
+import           Dungeon.Stairs (StairsPair (StairsPair, downStairs, upStairs))
+import           TreeZipper     (TreeZipper, getFocused, goDownBy, goUp, modify)
 
 type Dungeons = TreeZipper Dungeon
 
@@ -25,6 +29,19 @@ ascendStairsAtPlayerPosition ds = newZipper
                           (Just g, Just p, True) ->
                                 Just $ modify (\d -> updateMap $ d & actors %~ (:) p) g
                           _ -> Nothing
+
+descendStairsAtPlayerPosition :: Dungeons -> Maybe Dungeons
+descendStairsAtPlayerPosition ds = newZipper
+    where (player, zipperWithoutPlayer) = popPlayer ds
+          newPlayer = case (player, newPosition) of
+                          (Just p, Just pos) -> Just $ p & position .~ pos
+                          _                  -> Nothing
+          zipperFocusingNextDungeon = goDownBy (\x -> x ^. positionOnParentMap == fmap (^. position) player) zipperWithoutPlayer
+          newPosition = downStairs <$> find (\(StairsPair from _) -> Just from == fmap (^. position) player) (getFocused ds ^. descendingStairs)
+          newZipper = case (zipperFocusingNextDungeon, newPlayer) of
+                          (Just g, Just p) -> Just $ modify (\d -> updateMap $ d & actors %~ (:) p) g
+                          _ -> Nothing
+
 
 popPlayer :: TreeZipper Dungeon -> (Maybe Actor, Dungeons)
 popPlayer z = (fst $ D.popPlayer $ getFocused z, modify (snd . D.popPlayer) z)


### PR DESCRIPTION
- refactor: add `Dungeons.hs` and move a function
- refactor: move `descendStairsAtPlayerPosition`
- refactor: move `exitDungeon`
- refactor: move `doPlayerAction`
- refactor: remove an unused pragma
- refactor: define `popActorIf`
- refactor: move `handleNpcTurn`
